### PR TITLE
Sync version of `@vercel/remix` upon sync, and add npm publish

### DIFF
--- a/.github/workflow_scripts/sync-repo.js
+++ b/.github/workflow_scripts/sync-repo.js
@@ -3,79 +3,100 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = async ({ github, context }) => {
-    const { owner, repo } = context.repo;
+  const { owner, repo } = context.repo;
 
-    try {
-        const packageJSONPath = path.join(
-            __dirname,
-            '..',
-            '..',
-            'packages',
-            'remix-dev',
-            'package.json'
-        );
+  try {
+    const packageJSONPath = path.join(
+      __dirname,
+      '..',
+      '..',
+      'packages',
+      'remix-dev',
+      'package.json'
+    );
 
-        let packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));
+    let packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));
 
-        const existingVersion = packageJSON.version;
-    
-        await github.rest.repos.mergeUpstream({
+    const existingVersion = packageJSON.version;
+
+    await github.rest.repos.mergeUpstream({
+      owner,
+      repo,
+      branch: 'main',
+    });
+
+    execSync('git pull origin main');
+
+    packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));
+
+    const newVersion = packageJSON.version;
+
+    if (existingVersion !== newVersion) {
+      // Sync the version in the `@vercel/remix` package
+      const vercelRemixPackageJSONPath = path.join(
+        __dirname,
+        '..',
+        '..',
+        'packages',
+        'vercel-remix',
+        'package.json'
+      );
+      const vercelRemixPackageJSON = JSON.parse(
+        fs.readFileSync(vercelRemixPackageJSONPath, 'utf-8')
+      );
+      vercelRemixPackageJSON.version = newVersion;
+      fs.writeFileSync(
+        vercelRemixPackageJSONPath,
+        `${JSON.stringify(vercelRemixPackageJSON, null, 2)}\n`
+      );
+
+      execSync('git add packages/vercel-remix/package.json');
+      execSync(`git commit -m "Set version in @vercel/remix to ${newVersion}"`);
+      execSync('git push origin main');
+
+      await github.rest.actions.createWorkflowDispatch({
+        owner,
+        repo,
+        workflow_id: 'publish.yml',
+        ref: 'main',
+      });
+    }
+  } catch (err) {
+    // Conflict detected
+    if (err.status === 409) {
+      const commit = await github.rest.repos.getCommit({
+        owner: 'remix-run',
+        repo: 'remix',
+        ref: 'main',
+      });
+      const title = `Merge Conflict ❌`;
+      const body = `Latest commit: ${commit.data.html_url}`;
+      const issues = await github.rest.issues.listForRepo({
+        owner,
+        repo,
+      });
+      const existingIssue = issues.data.find((issue) => issue.title === title);
+      if (existingIssue) {
+        if (existingIssue.body !== body) {
+          await github.rest.issues.update({
             owner,
             repo,
-            branch: 'main',
+            issue_number: existingIssue.number,
+            body,
+          });
+        } else {
+          console.log(`Latest merge conflict commit did not change.`);
+        }
+      } else {
+        await github.rest.issues.create({
+          owner,
+          repo,
+          title,
+          body,
         });
-
-        execSync('git pull origin main');
-
-        packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));
-
-        const newVersion = packageJSON.version;
-
-        if (existingVersion !== newVersion) {
-            await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: 'publish.yml',
-                ref: 'main'
-            });
-        }
-
-    } catch (err) {
-        // Conflict detected
-        if (err.status === 409) {
-            const commit = await github.rest.repos.getCommit({
-                owner: 'remix-run',
-                repo: 'remix',
-                ref: 'main'
-            });
-            const title = `Merge Conflict ❌`;
-            const body = `Latest commit: ${commit.data.html_url}`;
-            const issues = await github.rest.issues.listForRepo({
-                owner,
-                repo,
-            });
-            const existingIssue = issues.data.find((issue) => issue.title === title);
-            if (existingIssue) {
-                if (existingIssue.body !== body) {
-                    await github.rest.issues.update({
-                        owner,
-                        repo,
-                        issue_number: existingIssue.number,
-                        body
-                    });
-                } else {
-                    console.log(`Latest merge conflict commit did not change.`)
-                }
-            } else {
-                await github.rest.issues.create({
-                    owner,
-                    repo,
-                    title,
-                    body
-                });
-            }
-        }
-
-        throw err
+      }
     }
+
+    throw err;
+  }
 };

--- a/.github/workflow_scripts/trigger-builder-update.js
+++ b/.github/workflow_scripts/trigger-builder-update.js
@@ -1,11 +1,11 @@
 module.exports = async ({ github, context }, version) => {
-    await github.rest.actions.createWorkflowDispatch({
-        owner: context.repo.owner,
-        repo: 'vercel',
-        workflow_id: 'update-remix-run-dev.yml',
-        ref: 'main',
-        inputs: {
-            'new-version': version
-        }
-    });
-}
+  await github.rest.actions.createWorkflowDispatch({
+    owner: context.repo.owner,
+    repo: 'vercel',
+    workflow_id: 'update-remix-run-dev.yml',
+    ref: 'main',
+    inputs: {
+      'new-version': version,
+    },
+  });
+};

--- a/.github/workflow_scripts/update-package.js
+++ b/.github/workflow_scripts/update-package.js
@@ -2,27 +2,46 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = async ({ github, context }, versionPostfix) => {
-    const packageJSONPath = path.join(
-        __dirname,
-        '..',
-        '..',
-        'packages',
-        'remix-dev',
-        'package.json'
-    );
+  const packagesDir = path.join(__dirname, '..', '..', 'packages');
+  const devPackageJSONPath = path.join(
+    packagesDir,
+    'remix-dev',
+    'package.json'
+  );
+  const vercelPackageJSONPath = path.join(
+    packagesDir,
+    'vercel-remix',
+    'package.json'
+  );
 
-    const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));
+  const devPackageJSON = JSON.parse(
+    fs.readFileSync(devPackageJSONPath, 'utf-8')
+  );
 
-    packageJSON.name = '@vercel/remix-run-dev'
+  devPackageJSON.name = '@vercel/remix-run-dev';
 
-    if (versionPostfix !== "") {
-        if (!/[a-z]+\.\d+/.test(versionPostfix)) {
-            throw new Error(`version-postfix, '${versionPostfix}', is invalid. Must be a word and a number seperated by a '.' character. Example: 'patch.1'`)
-        }
-        packageJSON.version = `${packageJSON.version}-${versionPostfix}`;
+  if (versionPostfix !== '') {
+    if (!/[a-z]+\.\d+/.test(versionPostfix)) {
+      throw new Error(
+        `version-postfix, '${versionPostfix}', is invalid. Must be a word and a number seperated by a '.' character. Example: 'patch.1'`
+      );
     }
+    devPackageJSON.version = `${devPackageJSON.version}-${versionPostfix}`;
 
-    fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2) + '\n');
+    const vercelPackageJSON = JSON.parse(
+      fs.readFileSync(vercelPackageJSONPath, 'utf-8')
+    );
+    vercelPackageJSON.version = `${vercelPackageJSON.version}-${versionPostfix}`;
+    fs.writeFileSync(
+      vercelPackageJSONPath,
+      JSON.stringify(vercelPackageJSON, null, 2) + '\n'
+    );
+  }
 
-    return packageJSON.version
+  fs.writeFileSync(
+    devPackageJSONPath,
+    JSON.stringify(devPackageJSON, null, 2) + '\n'
+  );
+
+  return devPackageJSON.version;
 };

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,6 @@ jobs:
           cache: "yarn"
       - name: Install
         run: yarn --frozen-lockfile
-      - name: Build
-        run : yarn build:vercel
       - name: Update package
         id: update-package
         uses: actions/github-script@v6
@@ -31,8 +29,14 @@ jobs:
           script: |
             const script = require('./.github/workflow_scripts/update-package.js');
             return await script({ github, context }, "${{ inputs.version-postfix }}");
-      - name: Publish
+      - name: Build
+        run : yarn build:vercel
+      - name: Publish @vercel/remix-run-dev
         run: cd packages/remix-dev && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+      - name: Publish @vercel/remix
+        run: cd packages/vercel-remix && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
       - name: Update package


### PR DESCRIPTION
In the Sync workflow, when the versions in the Remix packages changes, update the version of `@vercel/remix` to match as well.

In the Publish workflow, also publish the `@vercel/remix` package.

Also ran `prettier` on the workflow files, so I suggest reviewing with [whitespace hidden](https://github.com/vercel/remix/pull/17/files?w=1).