### PR TITLE
[vercel-remix] Add `createKvSessionStorage()` function

### DIFF
--- a/packages/vercel-remix/edge/implementations.ts
+++ b/packages/vercel-remix/edge/implementations.ts
@@ -5,8 +5,11 @@ import {
 } from "@remix-run/server-runtime";
 
 import { sign, unsign } from "./crypto";
+import { createKvSessionStorage } from "../sessions";
 
 export const createCookie = createCookieFactory({ sign, unsign });
 export const createCookieSessionStorage =
   createCookieSessionStorageFactory(createCookie);
 export const createSessionStorage = createSessionStorageFactory(createCookie);
+export const createKvSessionStorage =
+  createKvStorageFactory(createSessionStorage);

--- a/packages/vercel-remix/edge/index.ts
+++ b/packages/vercel-remix/edge/index.ts
@@ -1,6 +1,7 @@
 export {
   createCookie,
   createCookieSessionStorage,
+  createKvSessionStorage,
   createSessionStorage,
 } from "./implementations";
 

--- a/packages/vercel-remix/implementations.ts
+++ b/packages/vercel-remix/implementations.ts
@@ -1,0 +1,6 @@
+import { createSessionStorage } from "@remix-run/node";
+
+import { createKvSessionStorageFactory } from "./sessions";
+
+export const createKvSessionStorage =
+  createKvSessionStorageFactory(createSessionStorage);

--- a/packages/vercel-remix/index.ts
+++ b/packages/vercel-remix/index.ts
@@ -4,6 +4,8 @@ export {
   createSessionStorage,
 } from "@remix-run/node";
 
+export { createKvSessionStorage } from "./implementations";
+
 export {
   createSession,
   defer,

--- a/packages/vercel-remix/sessions.ts
+++ b/packages/vercel-remix/sessions.ts
@@ -1,0 +1,87 @@
+import type {
+  CreateSessionStorageFunction,
+  SessionData,
+  SessionIdStorageStrategy,
+} from "@remix-run/server-runtime";
+
+interface KvClient {
+  exists: (key: string) => Promise<number>;
+  del: (key: string) => Promise<number>;
+  get: <TData>(key: string) => Promise<TData | null>;
+  set: (
+    key: string,
+    value: string,
+    opts?: { pxat?: number }
+  ) => Promise<number>;
+}
+
+export interface KvSessionStorageOptions {
+  /**
+   * KV client from the `@vercel/kv` package.
+   */
+  kv: KvClient;
+
+  /**
+   * The Cookie used to store the session id on the client, or options used
+   * to automatically create one.
+   */
+  cookie: SessionIdStorageStrategy["cookie"];
+
+  /**
+   * Prefix of the Redis key name used for session data, followed by `:${id}`.
+   * @default "session".
+   */
+  prefix?: string;
+}
+
+const genRanHex = (size: number) =>
+  [...Array(size)]
+    .map(() => Math.floor(Math.random() * 16).toString(16))
+    .join("");
+
+export const createKvSessionStorageFactory = (
+  createSessionStorage: CreateSessionStorageFunction
+) => {
+  return <Data = SessionData, FlashData = Data>({
+    kv,
+    cookie,
+    prefix = "session",
+  }: KvSessionStorageOptions) => {
+    return createSessionStorage<Data, FlashData>({
+      cookie,
+      async createData(data, expires) {
+        while (true) {
+          let baseId = genRanHex(16);
+          let id = `${prefix}:${baseId}`;
+          if ((await kv.exists(id)) === 0) {
+            let str = JSON.stringify(data);
+            if (expires) {
+              await kv.set(id, str, { pxat: expires.getTime() });
+            } else {
+              await kv.set(id, str);
+            }
+            return id;
+          }
+        }
+      },
+      async readData(id) {
+        return (await kv.get(id)) || null;
+      },
+      async updateData(id, data, expires) {
+        let str = JSON.stringify(data);
+        if (str === "{}") {
+          // If the data is empty then delete the session key
+          return this.deleteData(id);
+        }
+        if (expires) {
+          await kv.set(id, str, { pxat: expires.getTime() });
+        } else {
+          await kv.set(id, str);
+        }
+      },
+      async deleteData(id) {
+        await kv.del(id);
+      },
+    });
+  };
+};


### PR DESCRIPTION
Creates a Remix session store backed by a Vercel KV database.

```ts
// app/session.server.ts
import kv from '@vercel/kv';
import { createKvSessionStorage } from '@vercel/remix';

const { getSession, commitSession, destroySession } = createKvSessionStorage({
  kv,
  cookie: {
    name: "__session",
    secrets: ["s3cret1"],
  }
});

export { getSession, commitSession, destroySession };
```