### PR TITLE
Export unstable_data()

### DIFF
--- a/packages/vercel-remix/edge/index.ts
+++ b/packages/vercel-remix/edge/index.ts
@@ -24,6 +24,7 @@ export {
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,
+  unstable_data,
 } from "@remix-run/server-runtime";
 
 export type {

--- a/packages/vercel-remix/index.ts
+++ b/packages/vercel-remix/index.ts
@@ -25,6 +25,7 @@ export {
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,
+  unstable_data,
 } from "@remix-run/server-runtime";
 
 export type {


### PR DESCRIPTION
The change in this PR exports the new `unstable_data` function of Remix v2.11.0 from `@remix-run/server-runtime` so that it is available to import from `@vercel/remix`.