### PR TITLE
remove: unstable_defineLoader and unstable_defineAction exports

### DIFF
--- a/packages/vercel-remix/edge/index.ts
+++ b/packages/vercel-remix/edge/index.ts
@@ -11,8 +11,6 @@ export {
   createRequestHandler,
   createSession,
   unstable_data,
-  unstable_defineLoader,
-  unstable_defineAction,
   defer,
   broadcastDevReady,
   logDevReady,

--- a/packages/vercel-remix/index.ts
+++ b/packages/vercel-remix/index.ts
@@ -12,8 +12,6 @@ export {
   createRequestHandler,
   createSession,
   unstable_data,
-  unstable_defineLoader,
-  unstable_defineAction,
   defer,
   broadcastDevReady,
   logDevReady,


### PR DESCRIPTION
In the new version of Remix 2.12, the export functions for unstable_defineLoader and unstable_defineAction have been removed. I have made these changes in the @vercel/remix package in this pull request, which means that the release of version 2.12 can now be created.